### PR TITLE
Add descriptions and minor changes to sigma-1.0.json

### DIFF
--- a/src/schemas/json/sigma-1.0.json
+++ b/src/schemas/json/sigma-1.0.json
@@ -95,6 +95,7 @@
       "references": {
         "type": "array",
         "description": "References to the source that the rule was derived from. These could be blog articles, technical papers, presentations or even tweets",
+        "uniqueItems": true,
         "items": {
           "type": "string"
         }
@@ -112,8 +113,19 @@
       "logsource": {
         "type": "object",
         "description": "The log source that the rule is supposed to detect malicious activity in.",
-        "items": {
-          "type": "string"
+        "properties": {
+          "category": {
+            "description": "Group of products, like firewall or process_creation",
+            "type": "string"
+          },
+          "product": {
+            "description": "A certain product, like windows",
+            "type": "string"
+          },
+          "service": {
+            "description": "A subset of a product's logs, like sshd",
+            "type": "string"
+          }
         }
       },
       "detection": {
@@ -121,6 +133,7 @@
         "required": ["condition"],
         "description": "A set of search-identifiers that represent properties of searches on log data",
         "additionalProperties": {
+          "description": "A Search Identifier: A definition that can consist of two different data structures - lists and maps.",
           "anyOf": [
             {
               "type": "array",
@@ -151,32 +164,22 @@
         },
         "properties": {
           "condition": {
-            "anyOf": [
-              {
-                "type": "string",
-                "description": "A search condition that is applied to the log data. The following format must be used: fieldname : value"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 2
-                }
-              }
-            ],
-            "description": "A set of search-identifiers that represent properties of searches on log data"
+            "type": "string",
+            "description": "The relationship between the search identifiers to create the detection logic. Ex: selection1 or selection2"
           }
         }
       },
       "fields": {
         "type": "array",
         "description": "A list of log fields that could be interesting in further analysis of the event and should be displayed to the analyst",
+        "uniqueItems": true,
         "items": {
           "type": "string"
         }
       },
       "falsepositives": {
         "description": "A list of known false positives that may occur",
+        "uniqueItems": true,
         "anyOf": [
           {
             "type": "string",
@@ -218,10 +221,12 @@
         ]
       },
       "tags": {
+        "description": "Tags to categorize a Sigma rule.",
         "type": "array",
+        "uniqueItems": true,
         "items": {
           "type": "string",
-          "pattern": "^[a-z0-9_.-]+$"
+          "pattern": "^[a-z0-9_-]+\\\\.[a-z0-9._-]+$"
         }
       }
     }


### PR DESCRIPTION
There are some stuff I didn't include because I'm not sure you'd like to see them in the schema, like this where it provides most of the time a description for the various modifiers:
![image](https://github.com/nasbench/schemastore/assets/14599855/715fcfd6-0f51-4eaf-8b87-9e562e5aeafd)


Also, your spec says that the `condition` field can be an array, which seemed weird, unless I'm missing something. Same goes for `falsepositives`, but I didn't change it.

I based my work on the sigma spec v2, so I didn't include everything since your content is about sigma v1.